### PR TITLE
03 - Add a GET /api/topics endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,17 +1,17 @@
 const endpointsJson = require("../endpoints.json");
 const app = require('../app');
 const request = require('supertest');
-// const seed = require('../db/seeds/seed');
-// const testData = require('../db/data/test-data/index');
-// const db = require('../db/connection');
+const seed = require('../db/seeds/seed');
+const testData = require('../db/data/test-data/index');
+const db = require('../db/connection');
 
-// beforeEach(() => {
-//   return seed(testData); // re-seed testData before each test.
-// });
+beforeEach(() => {
+  return seed(testData); // re-seed testData before each test.
+});
 
-// afterAll(() => {
-//   return db.end(); // close the database connection after all tests.
-// });
+afterAll(() => {
+  return db.end(); // close the database connection after all tests.
+});
 
 describe("GET /api", () => {
   test("200: Responds with an object detailing the documentation for each endpoint", () => {
@@ -23,3 +23,32 @@ describe("GET /api", () => {
       });
   });
 });
+
+describe("GET /api/topics", () => {
+  test("200: Responds with an array of topic objects", () => {
+    return request(app)
+      .get("/api/topics")
+      .expect(200)
+      .then(({ body }) => {
+        const { topics } = body;
+        expect(topics.length).toEqual(3);
+        topics.forEach((topic) => {
+          expect(topic).toMatchObject({
+            description: expect.any(String),
+            slug: expect.any(String),
+          })
+        })
+      });
+  });
+});
+
+describe("GET /api/not_an_endpoint", () => {
+  test("404: Responds with message 'Endpoint not found'.", () => {
+    return request(app)
+      .get("/api/not_an_endpoint")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Endpoint not found");
+      });
+  });
+})

--- a/app.js
+++ b/app.js
@@ -1,10 +1,26 @@
 const express = require("express");
 const endpointsJson = require("./endpoints.json");
+const { getTopics } = require("./controllers/topics.controllers")
 
 const app = express();
 
 app.get('/api', (req, res) => {
     res.status(200).send({ endpoints: endpointsJson });
 });
+
+app.get('/api/topics', getTopics);
+
+app.use((req, res) => {
+    res.status(404).send({ msg: "Endpoint not found" });
+});
+
+app.use((err, req, res, next) => {
+    if (err.status && err.msg) {
+        res.status(err.status).send(err.msg);
+    }
+    else {
+        res.status(500).send({ msg: "Internal Server Error" })
+    }
+})
 
 module.exports = app;

--- a/controllers/topics.controllers.js
+++ b/controllers/topics.controllers.js
@@ -1,0 +1,11 @@
+const { getTopicsData } = require("../models/topics.models");
+
+exports.getTopics = (req, res, next) => {
+    getTopicsData()
+        .then((rows) => {
+            res.status(200).send({ topics: rows })
+        })
+        .catch((err) => {
+            next(err);
+        })
+}

--- a/models/topics.models.js
+++ b/models/topics.models.js
@@ -1,0 +1,11 @@
+const db = require("../db/connection");
+
+exports.getTopicsData = () => {
+    return db.query(`SELECT * FROM topics`)
+        .then(({ rows }) => {
+            if (rows.length === 0) {
+                return Promise.reject({ status: 404, msg: "Data not found" })
+            }
+            else return rows;
+        })
+};


### PR DESCRIPTION
Add a GET /api/topics endpoint that responds with an array of topic objects, with error-handling for non-existent endpoints and 500 Internal Server Errors.